### PR TITLE
Add Functionality for Retrieving Network Credentials from IIS Impersonation

### DIFF
--- a/Src/Rainbow.Tfs/SourceControl/FileSyncTfs.cs
+++ b/Src/Rainbow.Tfs/SourceControl/FileSyncTfs.cs
@@ -11,36 +11,36 @@ namespace Rainbow.Tfs.SourceControl
 		private readonly WorkspaceInfo _workspaceInfo;
 		private readonly NetworkCredential _networkCredential;
 
-        public bool AllowFileSystemClear { get { return false; } }
-        
+		public bool AllowFileSystemClear { get { return false; } }
+		
 
 		public FileSyncTfs(ScmSettings settings)
 		{
-		    if (settings.UseImpersonation)
-		    {
-                var windowsIdentity = WindowsIdentity.GetCurrent();
-                if (windowsIdentity == null)
-                {
-                    throw new Exception("[Rainbow.Tfs] Unable to retrieve impersonated identity.");
-                }
+			if (settings.UseImpersonation)
+			{
+				var windowsIdentity = WindowsIdentity.GetCurrent();
+				if (windowsIdentity == null)
+				{
+					throw new Exception("[Rainbow.Tfs] Unable to retrieve impersonated identity.");
+				}
 
-                using (windowsIdentity.Impersonate())
-                {
-                    _networkCredential = CredentialCache.DefaultNetworkCredentials;
-                }
-            }
-		    else
-		    {
-                _networkCredential = new NetworkCredential(settings.Username, settings.Password, settings.Domain);
-            }
+				using (windowsIdentity.Impersonate())
+				{
+					_networkCredential = CredentialCache.DefaultNetworkCredentials;
+				}
+			}
+			else
+			{
+				_networkCredential = new NetworkCredential(settings.Username, settings.Password, settings.Domain);
+			}
 
-            _workspaceInfo = Workstation.Current.GetLocalWorkspaceInfo(settings.WorkspacePath);
-		    AssertWorkspace(_workspaceInfo, settings.WorkspacePath);
+			_workspaceInfo = Workstation.Current.GetLocalWorkspaceInfo(settings.WorkspacePath);
+			AssertWorkspace(_workspaceInfo, settings.WorkspacePath);
 
 			EnsureUpdateWorkspaceInfoCache();
 		}
 
-        private void AssertWorkspace(WorkspaceInfo workspaceInfo, string filename)
+		private void AssertWorkspace(WorkspaceInfo workspaceInfo, string filename)
 		{
 			if (workspaceInfo != null) return;
 			throw new Exception("[Rainbow.Tfs] No workspace is available or defined for the path. Verify your ASP.NET impersonation credentials in IIS for local TFS cache access. File " + filename);

--- a/Src/Rainbow.Tfs/SourceControl/FileSyncTfs.cs
+++ b/Src/Rainbow.Tfs/SourceControl/FileSyncTfs.cs
@@ -15,25 +15,25 @@ namespace Rainbow.Tfs.SourceControl
 
 		public FileSyncTfs(string username, string password, string domain)
 		{
-            // If no username is specified, we attempt to retrieve the Network
-            // Credentials based off the current impersonated identity
-		    if (string.IsNullOrWhiteSpace(username))
-		    {
-		        var windowsIdentity = WindowsIdentity.GetCurrent();
-		        if (windowsIdentity == null)
-		        {
-		            throw new Exception("[Rainbow.Tfs] Unable to retrieve impersonated identity.");
-		        }
+			// If no username is specified, we attempt to retrieve the Network
+			// Credentials based off the current impersonated identity
+			if (string.IsNullOrWhiteSpace(username))
+			{
+				var windowsIdentity = WindowsIdentity.GetCurrent();
+				if (windowsIdentity == null)
+				{
+					throw new Exception("[Rainbow.Tfs] Unable to retrieve impersonated identity.");
+				}
 
-		        using (windowsIdentity.Impersonate())
-		        {
-		            _networkCredential = CredentialCache.DefaultNetworkCredentials;
-		        }
-		    }
-		    else
-		    {
-                _networkCredential = new NetworkCredential(username, password, domain);
-            }
+				using (windowsIdentity.Impersonate())
+				{
+					_networkCredential = CredentialCache.DefaultNetworkCredentials;
+				}
+			}
+			else
+			{
+				_networkCredential = new NetworkCredential(username, password, domain);
+			}
 
 			var applicationRootPath = HttpContext.Current.Server.MapPath("/");
 			_workspaceInfo = Workstation.Current.GetLocalWorkspaceInfo(applicationRootPath);

--- a/src/Rainbow.Tfs/SourceControl/ScmSettings.cs
+++ b/src/Rainbow.Tfs/SourceControl/ScmSettings.cs
@@ -5,6 +5,7 @@ namespace Rainbow.Tfs.SourceControl
 		public string Username { get; set; }
 		public string Domain { get; set; }
 		public string Password { get; set; }
-		public string ApplicationRootPath { get; set; }
+		public string WorkspacePath { get; set; }
+	    public bool UseImpersonation { get; set; }
 	}
 }

--- a/src/Rainbow.Tfs/SourceControl/ScmSettings.cs
+++ b/src/Rainbow.Tfs/SourceControl/ScmSettings.cs
@@ -6,6 +6,6 @@ namespace Rainbow.Tfs.SourceControl
 		public string Domain { get; set; }
 		public string Password { get; set; }
 		public string WorkspacePath { get; set; }
-	    public bool UseImpersonation { get; set; }
+		public bool UseImpersonation { get; set; }
 	}
 }

--- a/src/Rainbow.Tfs/SourceControl/SourceControlManager.cs
+++ b/src/Rainbow.Tfs/SourceControl/SourceControlManager.cs
@@ -12,14 +12,14 @@ namespace Rainbow.Tfs.SourceControl
 		private string _username;
 		private string _password;
 		private string _domain;
-	    private string _workspacePath;
-	    private bool? _useImpersonation;
+		private string _workspacePath;
+		private bool? _useImpersonation;
 
 		private const string UsernameKey = "Rainbow.Tfs.Login";
 		private const string PasswordKey = "Rainbow.Tfs.Password";
 		private const string DomainKey = "Rainbow.Tfs.Domain";
-	    private const string WorkspacePathKey = "Rainbow.Tfs.WorkspacePath";
-	    private const string UseImpersonationKey = "Rainbow.Tfs.UseImpersonationCredentials";
+		private const string WorkspacePathKey = "Rainbow.Tfs.WorkspacePath";
+		private const string UseImpersonationKey = "Rainbow.Tfs.UseImpersonationCredentials";
 
 		protected string Username
 		{
@@ -60,52 +60,52 @@ namespace Rainbow.Tfs.SourceControl
 			}
 		}
 
-	    protected string WorkspacePath
-	    {
-	        get
-	        {
-	            if (!string.IsNullOrWhiteSpace(_workspacePath)) return _workspacePath;
+		protected string WorkspacePath
+		{
+			get
+			{
+				if (!string.IsNullOrWhiteSpace(_workspacePath)) return _workspacePath;
 
-	            var configSetting = Settings.GetSetting(WorkspacePath);
-	            _workspacePath = configSetting;
+				var configSetting = Settings.GetSetting(WorkspacePath);
+				_workspacePath = configSetting;
 
-	            return _workspacePath;
-	        }
-	    }
+				return _workspacePath;
+			}
+		}
 
-	    protected bool UseImpersonation
-	    {
-	        get
-	        {
-	            if (_useImpersonation.HasValue) return _useImpersonation.Value;
+		protected bool UseImpersonation
+		{
+			get
+			{
+				if (_useImpersonation.HasValue) return _useImpersonation.Value;
 
-	            var configSetting = Settings.GetBoolSetting(UseImpersonationKey, false);
-	            _useImpersonation = configSetting;
+				var configSetting = Settings.GetBoolSetting(UseImpersonationKey, false);
+				_useImpersonation = configSetting;
 
-	            return configSetting;
-	        }
-	    }
+				return configSetting;
+			}
+		}
 
 		private ScmSettings GetSettings()
 		{
-		    return new ScmSettings()
-		    {
-		        Domain = Domain,
-		        Password = Password,
-		        Username = Username,
-		        WorkspacePath = string.IsNullOrWhiteSpace(WorkspacePath)
-		            ? HttpContext.Current.Server.MapPath("/")
-		            : WorkspacePath,
-		        UseImpersonation = UseImpersonation
-		    };
+			return new ScmSettings()
+			{
+				Domain = Domain,
+				Password = Password,
+				Username = Username,
+				WorkspacePath = string.IsNullOrWhiteSpace(WorkspacePath)
+					? HttpContext.Current.Server.MapPath("/")
+					: WorkspacePath,
+				UseImpersonation = UseImpersonation
+			};
 		}
 
 		public SourceControlManager()
 		{
 			var settings = GetSettings();
 
-            SourceControlSync = new FileSyncTfs(settings);
-        }
+			SourceControlSync = new FileSyncTfs(settings);
+		}
 
 		public SourceControlManager(ISourceControlSync sourceControlSync)
 		{

--- a/src/Rainbow.Tfs/SourceControl/SourceControlManager.cs
+++ b/src/Rainbow.Tfs/SourceControl/SourceControlManager.cs
@@ -12,10 +12,14 @@ namespace Rainbow.Tfs.SourceControl
 		private string _username;
 		private string _password;
 		private string _domain;
+	    private string _workspacePath;
+	    private bool? _useImpersonation;
 
 		private const string UsernameKey = "Rainbow.Tfs.Login";
 		private const string PasswordKey = "Rainbow.Tfs.Password";
 		private const string DomainKey = "Rainbow.Tfs.Domain";
+	    private const string WorkspacePathKey = "Rainbow.Tfs.WorkspacePath";
+	    private const string UseImpersonationKey = "Rainbow.Tfs.UseImpersonationCredentials";
 
 		protected string Username
 		{
@@ -56,22 +60,52 @@ namespace Rainbow.Tfs.SourceControl
 			}
 		}
 
+	    protected string WorkspacePath
+	    {
+	        get
+	        {
+	            if (!string.IsNullOrWhiteSpace(_workspacePath)) return _workspacePath;
+
+	            var configSetting = Settings.GetSetting(WorkspacePath);
+	            _workspacePath = configSetting;
+
+	            return _workspacePath;
+	        }
+	    }
+
+	    protected bool UseImpersonation
+	    {
+	        get
+	        {
+	            if (_useImpersonation.HasValue) return _useImpersonation.Value;
+
+	            var configSetting = Settings.GetBoolSetting(UseImpersonationKey, false);
+	            _useImpersonation = configSetting;
+
+	            return configSetting;
+	        }
+	    }
+
 		private ScmSettings GetSettings()
 		{
-			return new ScmSettings()
-			{
-				Domain = Domain,
-				Password = Password,
-				Username = Username,
-				ApplicationRootPath = HttpContext.Current.Server.MapPath("/")
-			};
+		    return new ScmSettings()
+		    {
+		        Domain = Domain,
+		        Password = Password,
+		        Username = Username,
+		        WorkspacePath = string.IsNullOrWhiteSpace(WorkspacePath)
+		            ? HttpContext.Current.Server.MapPath("/")
+		            : WorkspacePath,
+		        UseImpersonation = UseImpersonation
+		    };
 		}
 
 		public SourceControlManager()
 		{
 			var settings = GetSettings();
-			SourceControlSync = new FileSyncTfs(settings.Username, settings.Password, settings.Domain);
-		}
+
+            SourceControlSync = new FileSyncTfs(settings);
+        }
 
 		public SourceControlManager(ISourceControlSync sourceControlSync)
 		{


### PR DESCRIPTION
Contains logic for populating the NetworkCredential object for communicating with TFS by retrieving the IIS-impersonated user, rather than pulling the credentials from a configuration file. This removes the requirement of storing a plain-text network password on disk.

Additionally, I've added two new settings:
- Rainbow.Tfs.WorkspacePath: Specify this to configure the location of the TFS workspace, if it is outside the webroot
- Rainbow.Tfs.UseImpersonationCredentials: If true, will use the IIS impersonation credentials when connecting to TFS, rather than the explicit Username/Password/Domain settings.
